### PR TITLE
Review and update OGR::SpatialReference::Importers, Exporters

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -30,6 +30,7 @@ target :lib do
         'lib/ogr/spatial_reference.rb',
         'lib/ogr/spatial_reference/coordinate_system_getter_setters.rb',
         'lib/ogr/spatial_reference/exporters.rb',
+        'lib/ogr/spatial_reference/importers.rb',
         'lib/ogr/style_*.rb',
         'lib/ogr/unknown_geometry.rb'
 

--- a/Steepfile
+++ b/Steepfile
@@ -29,6 +29,7 @@ target :lib do
         'lib/ogr/polygon.rb',
         'lib/ogr/spatial_reference.rb',
         'lib/ogr/spatial_reference/coordinate_system_getter_setters.rb',
+        'lib/ogr/spatial_reference/exporters.rb',
         'lib/ogr/style_*.rb',
         'lib/ogr/unknown_geometry.rb'
 

--- a/lib/ffi/ogr/srs_api/spatial_reference.rb
+++ b/lib/ffi/ogr/srs_api/spatial_reference.rb
@@ -18,6 +18,9 @@ module FFI
 
       attach_function :OSRValidate, %i[OGRSpatialReferenceH], FFI::OGR::Core::Err
 
+      #------------------
+      # Importers
+      #------------------
       attach_function :OSRImportFromEPSG, %i[OGRSpatialReferenceH int], FFI::OGR::Core::Err
       attach_function :OSRImportFromEPSGA, %i[OGRSpatialReferenceH int], FFI::OGR::Core::Err
       attach_function :OSRImportFromWkt, %i[OGRSpatialReferenceH pointer], FFI::OGR::Core::Err
@@ -31,12 +34,16 @@ module FFI
                       %i[OGRSpatialReferenceH long long pointer long],
                       FFI::OGR::Core::Err
       attach_function :OSRImportFromXML, %i[OGRSpatialReferenceH string], FFI::OGR::Core::Err
+      attach_function :OSRImportFromDict, %i[OGRSpatialReferenceH string string], FFI::OGR::Core::Err
       attach_function :OSRImportFromMICoordSys, %i[OGRSpatialReferenceH string], FFI::OGR::Core::Err
       attach_function :OSRImportFromERM,
                       %i[OGRSpatialReferenceH string string string],
                       FFI::OGR::Core::Err
       attach_function :OSRImportFromUrl, %i[OGRSpatialReferenceH string], FFI::OGR::Core::Err
 
+      #------------------
+      # Exporters
+      #------------------
       attach_function :OSRExportToWkt, %i[OGRSpatialReferenceH pointer], FFI::OGR::Core::Err
       attach_function :OSRExportToPrettyWkt, %i[OGRSpatialReferenceH pointer bool], FFI::OGR::Core::Err
       attach_function :OSRExportToProj4, %i[OGRSpatialReferenceH pointer], FFI::OGR::Core::Err
@@ -54,9 +61,16 @@ module FFI
       attach_function :OSRExportToERM,
                       %i[OGRSpatialReferenceH buffer_out buffer_out buffer_out],
                       FFI::OGR::Core::Err
+
+      #------------------
+      # Morphers
+      #------------------
       attach_function :OSRMorphToESRI, %i[OGRSpatialReferenceH], FFI::OGR::Core::Err
       attach_function :OSRMorphFromESRI, %i[OGRSpatialReferenceH], FFI::OGR::Core::Err
 
+      #------------------
+      #
+      #------------------
       attach_function :OSRSetAttrValue, %i[OGRSpatialReferenceH string string], FFI::OGR::Core::Err
       attach_function :OSRGetAttrValue, %i[OGRSpatialReferenceH string int], :string
       attach_function :OSRSetAngularUnits, %i[OGRSpatialReferenceH string double], FFI::OGR::Core::Err

--- a/lib/ffi/ogr/srs_api/spatial_reference.rb
+++ b/lib/ffi/ogr/srs_api/spatial_reference.rb
@@ -43,6 +43,9 @@ module FFI
       attach_function :OSRExportToPCI,
                       %i[OGRSpatialReferenceH pointer pointer pointer],
                       FFI::OGR::Core::Err
+      attach_function :OSRExportToPanorama,
+                      %i[OGRSpatialReferenceH pointer pointer pointer pointer pointer],
+                      FFI::OGR::Core::Err
       attach_function :OSRExportToUSGS,
                       %i[OGRSpatialReferenceH pointer pointer pointer pointer],
                       FFI::OGR::Core::Err

--- a/lib/ogr/spatial_reference/importers.rb
+++ b/lib/ogr/spatial_reference/importers.rb
@@ -5,7 +5,7 @@ require_relative '../error_handling'
 module OGR
   class SpatialReference
     module Importers
-      # @param code [Integer]
+      # @param code [Integer] EPSG geographic, projected or vertical CRS code.
       # @return [OGR::SpatialReference] `self`, but updated with the EPSG code.
       # @raise [GDAL::UnsupportedOperation] On unknown EPSG code.
       def import_from_epsg(code)
@@ -18,6 +18,7 @@ module OGR
 
       # @param code [Integer]
       # @raise [OGR::Failure]
+      # @note Since GDAL 3.0, this method is identical to #import_from_epsg.
       def import_from_epsga(code)
         OGR::ErrorHandling.handle_ogr_err("Unable to import from EPSGA: #{code}") do
           FFI::OGR::SRSAPI.OSRImportFromEPSGA(@c_pointer, code)
@@ -29,8 +30,10 @@ module OGR
       # @param wkt [String]
       # @raise [OGR::Failure]
       def import_from_wkt(wkt)
-        wkt_ptr = FFI::MemoryPointer.from_string(wkt)
-        wkt_ptr_ptr = FFI::MemoryPointer.new(:pointer)
+        wkt_ptr = FFI::Buffer.new_in(:string)
+        wkt_ptr.put_string(0, wkt)
+
+        wkt_ptr_ptr = FFI::Buffer.new_in(:pointer)
         wkt_ptr_ptr.write_pointer(wkt_ptr)
 
         OGR::ErrorHandling.handle_ogr_err("Unable to import from WKT: #{wkt}") do
@@ -40,6 +43,12 @@ module OGR
         self
       end
 
+      # The SpatialReference is updated from the given PROJ-style coordinate system string.
+      #
+      # Example: pszProj4 = "+proj=utm +zone=11 +datum=WGS84"
+      #
+      # It is also possible to import "+init=epsg:n" style definitions.
+      #
       # @param proj4 [String]
       # @raise [OGR::Failure]
       def import_from_proj4(proj4)
@@ -50,6 +59,25 @@ module OGR
         self
       end
 
+      # Import coordinate system from ESRI .prj format(s).
+      #
+      # This function will read the text loaded from an ESRI .prj file, and translate
+      # it into an OGRSpatialReference definition. This should support many (but
+      # by no means all) old style (Arc/Info 7.x) .prj files, as well as the newer
+      # pseudo-OGC WKT .prj files. Note that new style .prj files are in OGC WKT
+      # format, but require some manipulation to correct datum names, and units
+      # on some projection parameters. This is addressed within #import_from_esri
+      # by an automatic call to #morph_from_esri
+      #
+      # Currently only GEOGRAPHIC, UTM, STATEPLANE, GREATBRITIAN_GRID, ALBERS,
+      # EQUIDISTANT_CONIC, TRANSVERSE (mercator), POLAR, MERCATOR and POLYCONIC
+      # projections are supported from old style files.
+      #
+      # At this time there is no equivalent #to_esri method. Writing old style
+      # .prj files is not supported by SpatialReference. However the #morph_to_esri
+      # and #to_wkt methods can be used to generate output suitable to write to
+      # new style (Arc 8) .prj files.
+      #
       # @param esri_text [Array<String>]
       # @raise [OGR::Failure]
       def import_from_esri(esri_text)
@@ -63,11 +91,37 @@ module OGR
         self
       end
 
-      # @param proj [String]
-      # @param units [String]
-      # @param proj_params [Array<String>]
+      # PCI software uses 16-character string to specify coordinate system and
+      # datum/ellipsoid. You should supply at least this string here.
+      #
+      # @param projection_string [String] String containing the definition. Looks
+      #   like "pppppppppppp Ennn" or "pppppppppppp Dnnn", where "pppppppppppp"
+      #   is a projection code, "Ennn" is an ellipsoid code, "Dnnn" a datum code.
+      # @param units [String, nil] Grid units code "DEGREE" or "METRE"). If nil,
+      #   "METRE" will be used.
+      # @param proj_params [Array<String>] Array of 17 coordinate system parameters.
+      #   Particular projections use different parameters; unused ones may be set
+      #   to zero. If nil is supplied instead of an array, default values will
+      #   be used (i.e., zeroes). Params are:
+      #   [0] Spheroid semi major axis
+      #   [1] Spheroid semi minor axis
+      #   [2] Reference Longitude
+      #   [3] Reference Latitude
+      #   [4] First Standard Parallel
+      #   [5] Second Standard Parallel
+      #   [6] False Easting
+      #   [7] False Northing
+      #   [8] Scale Factor
+      #   [9] Height above sphere surface
+      #   [10] Longitude of 1st point on center line
+      #   [11] Latitude of 1st point on center line
+      #   [12] Longitude of 2nd point on center line
+      #   [13] Latitude of 2nd point on center line
+      #   [14] Azimuth east of north for center line
+      #   [15] Landsat satellite number
+      #   [16] Landsat path number
       # @raise [OGR::Failure]
-      def import_from_pci(proj, units, *proj_params)
+      def import_from_pci(projection_string, units, proj_params = nil)
         if proj_params.empty?
           proj_ptr = nil
         else
@@ -75,19 +129,23 @@ module OGR
           proj_ptr.write_array_of_double(proj_params)
         end
 
-        OGR::ErrorHandling.handle_ogr_err("Unable to import from PCI: #{proj}") do
-          FFI::OGR::SRSAPI.OSRImportFromPCI(@c_pointer, proj, units, proj_ptr)
+        OGR::ErrorHandling.handle_ogr_err("Unable to import from PCI: #{projection_string}") do
+          FFI::OGR::SRSAPI.OSRImportFromPCI(@c_pointer, projection_string, units, proj_ptr)
         end
 
         self
       end
 
-      # @param projection_system_code [Integer]
-      # @param zone [Integer]
-      # @param datum [Integer]
-      # @param proj_params [Array<Float>]
+      # @param projection_system_code [Integer] Input projection system code, used in GCTP.
+      # @param zone [Integer] Input zone for UTM and State Plane projection systems.
+      #   For Southern Hemisphere UTM use a negative zone code; ignored for all
+      #   other projections.
+      # @param datum [Integer] Input spheroid.
+      # @param proj_params [Array<Float>] Array of 15 coordinate system parameters.
+      #   These parameters differ for different projections.
       # @raise [OGR::Failure]
-      def import_from_usgs(projection_system_code, zone, datum, *proj_params)
+      # @see https://gdal.org/api/ogrspatialref.html#classOGRSpatialReference_1a4a971615901e5c4a028e6b49fb5918d9
+      def import_from_usgs(projection_system_code, zone, datum, proj_params)
         if proj_params.empty?
           proj_ptr = nil
         else
@@ -105,6 +163,67 @@ module OGR
             proj_ptr,
             datum
           )
+        end
+
+        self
+      end
+
+      # Import coordinate system from "Panorama" GIS projection definition.
+      #
+      # @param projection_system_code [Integer]
+      # @param datum [Integer] Input coordinate system.
+      # @param spheroid [Integer]
+      # @param proj_params [Array<Float>] Array of 8 coordinate system parameters.
+      #   These parameters differ for different projections.
+      # @see https://gdal.org/api/ogrspatialref.html#_CPPv4N19OGRSpatialReference18importFromPanoramaElllPd
+      def import_from_panorama(projection_system_code, datum, spheroid, proj_params)
+        if proj_params.empty?
+          proj_params_ptr = nil
+        else
+          proj_params_ptr = FFI::MemoryPointer.new(:double, proj_params.size)
+          proj_params_ptr.write_array_of_double(proj_params)
+        end
+
+        msg = "Unable to import from Panorama: #{projection_system_code}, #{datum}, #{spheroid}, #{proj_params}"
+
+        OGR::ErrorHandling.handle_ogr_err(msg) do
+          FFI::OGR::SRSAPI.OSRImportFromPanorama(
+            @c_pointer,
+            projection_system_code,
+            datum,
+            spheroid,
+            proj_params_ptr
+          )
+        end
+
+        self
+      end
+
+      # Read SRS from a WKT dictionary. This method will attempt to find the indicated
+      # coordinate system identity in the indicated dictionary file. If found, the
+      # WKT representation is imported and used to initialize this SpatialReference.
+      #
+      # @param dictionary_file_path [String]
+      # @param dictionary_lookup_code [String]
+      # @raise [OGR::Failure]
+      def import_from_dict(dictionary_file_path, dictionary_lookup_code)
+        OGR::ErrorHandling.handle_ogr_err("Unable to import from WKT dictionary: #{dictionary_file_path}") do
+          FFI::OGR::SRSAPI.OSRImportFromDict(@c_pointer, dictionary_file_path, dictionary_lookup_code)
+        end
+
+        self
+      end
+
+      # Import coordinate system from OziExplorer projection definition.
+      #
+      # @param map_file_lines [Array<String>] This is an array of strings
+      #   containing the whole OziExplorer .MAP file.
+      # @raise [OGR::Failure]
+      def import_from_ozi(map_file_lines)
+        array_ptr = GDAL._string_array_to_pointer(map_file_lines)
+
+        OGR::ErrorHandling.handle_ogr_err('Unable to import from Ozi .map file') do
+          FFI::OGR::SRSAPI.OSRImportFromOzi(@c_pointer, array_ptr)
         end
 
         self

--- a/sig-gems/ffi/1.15.3/ffi/abstract_memory.rbs
+++ b/sig-gems/ffi/1.15.3/ffi/abstract_memory.rbs
@@ -119,7 +119,7 @@ module FFI
     def write_int32: (Integer value) -> self
     def write_int64: (Integer value) -> self
     def write_int8: (Integer value) -> self
-    def write_pointer: (nil | FFI::Pointer | Integer | _ToPtr value) -> self
+    def write_pointer: (nil | FFI::Pointer | FFI::Buffer | Integer | _ToPtr value) -> self
     def write_uint16: (Integer offset) -> self
     def write_uint32: (Integer offset) -> self
     def write_uint64: (Integer offset) -> self

--- a/sig-gems/ffi/1.15.3/ffi/abstract_memory.rbs
+++ b/sig-gems/ffi/1.15.3/ffi/abstract_memory.rbs
@@ -33,7 +33,7 @@ module FFI
     def get_int8: (Integer offset) -> Integer
     def get_long: (Integer offset) -> Integer
     def get_pointer: (Integer offset) -> FFI::Pointer
-    def get_string: (Integer offset, Integer ?length) -> String
+    def get_string: (Integer offset, ?Integer ?length) -> String
     def get_uint16: (Integer offset) -> Integer
     def get_uint32: (Integer offset) -> Integer
     def get_uint64: (Integer offset) -> Integer

--- a/sig-gems/ffi/1.15.3/ffi/buffer.rbs
+++ b/sig-gems/ffi/1.15.3/ffi/buffer.rbs
@@ -2,5 +2,11 @@ module FFI
   class Buffer < FFI::AbstractMemory
     def self.alloc_out: (Integer | Symbol | _Size size, ?Integer count, ?bool clear) -> instance
     alias self.new_out self.alloc_out
+
+    def self.alloc_in: (Integer | Symbol | _Size size, ?Integer count, ?bool clear) -> instance
+    alias self.new_in self.alloc_in
+
+    def self.alloc_inout: (Integer | Symbol | _Size size, ?Integer count, ?bool clear) -> instance
+    alias self.new_inout self.alloc_inout
   end
 end

--- a/sig-gems/ffi/1.15.3/ffi/pointer.rbs
+++ b/sig-gems/ffi/1.15.3/ffi/pointer.rbs
@@ -2,6 +2,9 @@ module FFI
   class Pointer < FFI::AbstractMemory
     include _Inspect
 
+    SIZE: Integer
+    NULL: FFI::Pointer
+
     def initialize:
       (instance pointer)                     -> void
     | (FFI::Type type_name, Integer address) -> void

--- a/sig/ffi/ogr/api/style_manager.rbs
+++ b/sig/ffi/ogr/api/style_manager.rbs
@@ -11,8 +11,8 @@ module FFI
       def self.OGR_SM_InitFromFeature: (ogr_style_mgr_h c_pointer, FFI::OGR::API::ogr_feature_h) -> String
       def self.OGR_SM_InitStyleString: (ogr_style_mgr_h c_pointer, String style_string) -> bool
 
-      def self.OGR_SM_GetPartCount: (ogr_style_mgr_h c_pointer, String style_string) -> int
-      def self.OGR_SM_GetPart: (ogr_style_mgr_h c_pointer, Integer part_id, String style_string) -> FFI::OGR::API::ogr_style_tool_h
+      def self.OGR_SM_GetPartCount: (ogr_style_mgr_h c_pointer, FFI::Pointer style_string_pointer) -> int
+      def self.OGR_SM_GetPart: (ogr_style_mgr_h c_pointer, Integer part_id, FFI::Pointer style_string_pointer) -> FFI::OGR::API::ogr_style_tool_h
 
       def self.OGR_SM_AddPart: (ogr_style_mgr_h c_pointer, FFI::OGR::API::ogr_style_tool_h style_tool_ptr) -> bool
       def self.OGR_SM_AddStyle: (ogr_style_mgr_h c_pointer, String style_name, String style_string) -> bool

--- a/sig/ffi/ogr/srs_api/spatial_reference.rbs
+++ b/sig/ffi/ogr/srs_api/spatial_reference.rbs
@@ -220,7 +220,69 @@ module FFI
       def self.OSRExportToMICoordSys: (
         ogr_spatial_reference_h c_pointer,
         FFI::MemoryPointer mapinfo_coordsys_out,
-      ) -> (:OGRERR_NONE | :OGRERR_UNSUPPORTED_SRS | :OGR_FAILURE)
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      #--------------------
+      # Importers
+      #--------------------
+      def self.OSRImportFromEPSG: (ogr_spatial_reference_h c_pointer, Integer code) -> FFI::OGR::Core::ogr_err_symbol
+      def self.OSRImportFromEPSGA: (ogr_spatial_reference_h c_pointer, Integer code) -> FFI::OGR::Core::ogr_err_symbol
+      def self.OSRImportFromWkt: (ogr_spatial_reference_h c_pointer, FFI::Buffer wkt_in) -> (:OGRERR_NONE | :OGRERR_CORRUPT_DATA)
+      def self.OSRImportFromProj4: (ogr_spatial_reference_h c_pointer, String proj4_string) -> (:OGRERR_NONE | :OGRERR_CORRUPT_DATA)
+      def self.OSRImportFromESRI: (ogr_spatial_reference_h c_pointer, FFI::MemoryPointer string_array) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRImportFromPCI: (
+        ogr_spatial_reference_h c_pointer,
+        String projection_string,
+        ("DEGREE" | "METER") ?units,
+        FFI::MemoryPointer ?prj_params
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRImportFromUSGS: (
+        ogr_spatial_reference_h c_pointer,
+        Integer projection_system_code,
+        Integer zone,
+        FFI::MemoryPointer ?prj_params,
+        Integer datum
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRImportFromPanorama: (
+        ogr_spatial_reference_h c_pointer,
+        Integer projection_system_code,
+        Integer datum,
+        Integer spheroid,
+        FFI::MemoryPointer ?prj_params
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRImportFromXML: (ogr_spatial_reference_h c_pointer, String xml) -> (:OGRERR_NONE | :OGRERR_CORRUPT_DATA)
+
+      def self.OSRImportFromDict: (
+        ogr_spatial_reference_h c_pointer,
+        String dictionary_file_path,
+        String dictionary_lookup_code
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRImportFromOzi: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer map_file_lines
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRImportFromMICoordSys: (
+        ogr_spatial_reference_h c_pointer,
+        String map_info_coordsys
+      ) -> (:OGRERR_NONE | :OGRERR_FAILURE | :OGRERR_UNSUPPORTED_OPERATION)
+
+      def self.OSRImportFromERM: (
+        ogr_spatial_reference_h c_pointer,
+        String projection_name,
+        String datum_name,
+        ("FEET" | "METERS") linear_units
+      ) -> (:OGRERR_NONE | :OGRERR_UNSUPPORTED_SRS)
+
+      def self.OSRImportFromUrl: (
+        ogr_spatial_reference_h c_pointer,
+        String url,
+      ) -> FFI::OGR::Core::ogr_err_symbol
     end
   end
 end

--- a/sig/ffi/ogr/srs_api/spatial_reference.rbs
+++ b/sig/ffi/ogr/srs_api/spatial_reference.rbs
@@ -161,6 +161,66 @@ module FFI
         Float false_northing
       ) -> FFI::OGR::Core::ogr_err_symbol
 
+      #--------------------
+      # Exporters
+      #--------------------
+      def self.OSRExportToWkt: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer wkt_out,
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToPrettyWkt: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer wkt_out,
+        bool should_simplify
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToProj4: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer proj4_out,
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToPCI: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer pci_out,
+        FFI::MemoryPointer units_out,
+        FFI::MemoryPointer projection_params_out,
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToUSGS: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::Buffer projection_system_out,
+        FFI::Buffer zone_out,
+        FFI::MemoryPointer projection_params_out,
+        FFI::Buffer datum_out,
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToXML: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer xml_out,
+        FFI::Pointer ?dialect,
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToPanorama: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::Buffer projection_system_code_out,
+        FFI::Buffer datum_out,
+        FFI::Buffer spheroid_code_out,
+        FFI::Buffer zone_out,
+        FFI::MemoryPointer projection_params_out,
+      ) -> FFI::OGR::Core::ogr_err_symbol
+
+      def self.OSRExportToERM: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::Buffer projection_name_out,
+        FFI::Buffer datum_name_out,
+        FFI::Buffer units_name_out,
+      ) -> (:OGRERR_NONE | :OGRERR_UNSUPPORTED_SRS | :OGR_FAILURE)
+
+      def self.OSRExportToMICoordSys: (
+        ogr_spatial_reference_h c_pointer,
+        FFI::MemoryPointer mapinfo_coordsys_out,
+      ) -> (:OGRERR_NONE | :OGRERR_UNSUPPORTED_SRS | :OGR_FAILURE)
     end
   end
 end

--- a/spec/unit/ogr/spatial_reference_mixins/exporters_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/exporters_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe OGR::SpatialReference do
 
       it 'returns a Hash' do
         expect(subject.to_pci).to eq(
-          projection: 'LONG/LAT    D001',
+          projection_name: 'LONG/LAT    D001',
           units: 'DEGREE',
           projection_parameters: []
         )
@@ -53,7 +53,7 @@ RSpec.describe OGR::SpatialReference do
     context 'empty SRS' do
       it 'returns default values' do
         expect(subject.to_pci).to eq(
-          projection: 'LONG/LAT    E012',
+          projection_name: 'LONG/LAT    E012',
           units: 'DEGREE',
           projection_parameters: []
         )


### PR DESCRIPTION
I went through the OGR docs and the related functions in ffi-gdal to make sure they were still doing the right things (after all this time). Ended up adding some docs, wrapping a new function or two, adding typedefs, and making a few minor internal changes.