### PR TITLE
DEV-20059 Ensure GDAL::RasterBandClassifier#equal_count_ranges has a …

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,12 @@
 
 Format for this file derived from [http://keepachangelog.com](http://keepachangelog.com).
 
+## 1.0.0.beta15 / 2022-05-12
+
+### Improvements
+
+* [DEV-20059] Ensure `GDAL::RasterBandClassifier#equal_count_ranges` has a minimum spacing between breakpoints.
+
 ## 1.0.0.beta14 / 2022-05-06
 
 ### Bug Fixes

--- a/lib/ffi/gdal/version.rb
+++ b/lib/ffi/gdal/version.rb
@@ -2,6 +2,6 @@
 
 module FFI
   module GDAL
-    VERSION = '1.0.0.beta14'
+    VERSION = '1.0.0.beta15'
   end
 end

--- a/spec/unit/gdal/raster_band_classifier_spec.rb
+++ b/spec/unit/gdal/raster_band_classifier_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe GDAL::RasterBandClassifier do
     end
   end
 
+  describe '#ensure_min_gap' do
+    let(:break_values) do
+      [29_491.177616329518, 34_999.999999999985, 34_999.99999999999, 35_000.0, 35_000.01582852495, 36_499.9508667737]
+    end
+
+    let(:expected_values) do
+      [29_438.61973121367, 34_947.44211488414, 34_982.48598113636, 35_017.52984738857, 35_052.57371364079,
+       36_552.508751889545]
+    end
+
+    it 'ensures breakpoints have a gap between them of 0.5% of the total range' do
+      subject.send(:ensure_min_gap, break_values)
+      expect(break_values).to eq expected_values
+    end
+  end
+
   describe '#classify!' do
     before do
       ranges = subject.equal_count_ranges(10)


### PR DESCRIPTION
…minimum spacing between breakpoints
before:
![image](https://user-images.githubusercontent.com/325748/167965609-59db48b8-8cd4-459d-ac96-dee69e11c6ab.png)
after:
![image](https://user-images.githubusercontent.com/325748/167965619-a2bd441b-e77b-4477-86b5-f725a8f13d65.png)
