### PR TITLE
Adding file to allow backstage induction

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: null
+metadata:
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: agrian-inc/ffi-gdal
+  description: null
+  links:
+  - title: source code location
+    url: https://github.com/agrian-inc/ffi-gdal
+  name: ffi-gdal
+  tags:
+  - ruby
+  - agriannextgen
+  - static
+  - agribusiness
+spec:
+  consumesApis: []
+  lifecycle: production
+  owner: user:turboladen
+  providesApis: []
+  type: Library


### PR DESCRIPTION
We are adding a `catalog-info.yaml` to repos to allow them to be ingested by backstage, before this branch can be merged to master you should make changes to the following:
- `kind` should be set to one of: `Component`, `API`, or `Resources`, you can find a definition [here](https://backstage.io/docs/features/software-catalog/system-model)
- `description`: should be filled in with something meaningful, you should assume to a non-technical person to help clarify it
- `links`: should be expanded with additional useful links if you have any one has been provided as an example, good items to link to are documentation, online resources/tools etc.and potentially your hosted application.
- `tags`: you can expand your tags with anything useful, we suggest leveraged cloud services, to assist in searchability, rules for tags can be found [here](https://backstage.io/docs/features/software-catalog/descriptor-format#tags-optional)
- `consumesApis` & `providesApis`: should be a list of APIs that you consume that are provided by other repos.
- `owner`: should set to `user:{github id}` where the github id is the id of the person responsible for the repo either a team or technical lead, or `group:{group id}` and be set to the github group responsible for the repo. An attempt at this was made but should be reviewed for correctness.
For further reference you can see the the completed version for BB8's `catalog-info.yaml` [here](https://github.com/agrian-inc/bb-8/blob/master/catalog-info.yaml)
